### PR TITLE
URI Change

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ class webClient {
     console.log('[web] (login) authenticating');
 
     this.request.post({
-      url: '/authenticate',
+      url: '/launcher/1/authenticate',
       headers: makeHeaders({
         'Referer': 'https://account.enmasse.com/',
       }),


### PR DESCRIPTION
Fixes status code != 200. Redirect was happening despite being at the
wrong URI as that URI is still functional, but will return 404 on /launcher/1/account_server_info.